### PR TITLE
Handle transient_local durability when cutting bags

### DIFF
--- a/ros2bag_tools/ros2bag_tools/filter/cut.py
+++ b/ros2bag_tools/ros2bag_tools/filter/cut.py
@@ -13,8 +13,13 @@
 # limitations under the License.
 
 import argparse
+import yaml
 from datetime import datetime, time, timezone
+from rclpy.qos import QoSDurabilityPolicy
+from rclpy.serialization import serialize_message
+from ros2bag_tools.reader import TopicDeserializer
 from ros2bag_tools.filter import FilterExtension, FilterResult
+from ros2bag_tools.filter.restamp import set_header_stamp
 from ros2bag_tools.time import DurationOrDayTimeType, DurationType, get_bag_bounds, is_same_day,\
     datetime_to_ros_time, add_daytime, ros_to_datetime_utc
 
@@ -55,6 +60,10 @@ class CutFilter(FilterExtension):
         self._start_arg = None
         self._end_arg = None
         self._duration_arg = None
+        self._transient_local_policy = None
+        self._transient_local_policy_arg = None
+        self._topic_qos_durability_dict = {}
+        self._deserializer = TopicDeserializer()
 
     def add_arguments(self, parser):
         self._start_arg = parser.add_argument(
@@ -66,10 +75,20 @@ class CutFilter(FilterExtension):
         self._duration_arg = parser.add_argument(
             '--duration', help='duration of the output time span',
             type=DurationType)
+        self._transient_local_policy_arg = parser.add_argument(
+            '--transient-local-policy',
+            default='snap',
+            choices=['snap', 'keep', 'drop'],
+            help='Specifiy how to handle messages with transient_local durability with timestamps '
+            'prior to the start cut time, defaults to "snap". '
+            '"snap": set timestamp of prior transient_local messages to the start time '
+            'of the new bag. '
+            '"keep": keep prior transient_local messages with their original timestamp, '
+            'might lead to time gaps in the bag. '
+            '"drop": drop all prior transient_local messages')
 
-    def set_args(self, metadata, args):
-        (bag_start, bag_end) = get_bag_bounds(metadata)
-
+    def set_args(self, metadatas, args):
+        (bag_start, bag_end) = get_bag_bounds(metadatas)
         if args.start is not None and args.end is not None and args.duration is not None:
             raise argparse.ArgumentError(
                 self._duration_arg,
@@ -113,6 +132,12 @@ class CutFilter(FilterExtension):
         self._start_time = datetime_to_ros_time(start)
         self._end_time = datetime_to_ros_time(end)
 
+        self._transient_local_policy = args.transient_local_policy
+        for metadata in metadatas:
+            for topic in metadata.topics_with_message_count:
+                self._topic_qos_durability_dict[topic.topic_metadata.name] = yaml.safe_load(
+                    topic.topic_metadata.offered_qos_profiles)[0]['durability']
+
     def output_size_factor(self, metadata):
         start = metadata.starting_time.astimezone(timezone.utc)
         end = start + metadata.duration
@@ -124,15 +149,30 @@ class CutFilter(FilterExtension):
             end = filter_end
         return min(1, max(0, (end - start) / metadata.duration))
 
-    def filter_msg(self, msg):
-        (_, _, t) = msg
+    def filter_topic(self, topic_metadata):
+        self._deserializer.add_topic(topic_metadata)
+        return topic_metadata
+
+    def filter_msg(self, serialized_msg):
+        (topic, data, t) = serialized_msg
         # You may assume that this filtering is not necessary, as get_storage_filter sets
         # the filters on storage level. There are two cases when this is not sufficient:
         # * filters sequenced before or after this instance of cut may change the message
         #   timestamp to something else than in the bag data
         # * the underlying storage implementation does not support storage time filters
         if t < self._start_time.nanoseconds:
-            return FilterResult.DROP_MESSAGE
+            if self._topic_qos_durability_dict[topic] == QoSDurabilityPolicy.TRANSIENT_LOCAL:
+                if self._transient_local_policy == 'drop':
+                    return FilterResult.DROP_MESSAGE
+                elif self._transient_local_policy == 'snap':
+                    msg = self._deserializer.deserialize(topic, data)
+                    msg = set_header_stamp(msg, self._start_time.nanoseconds)
+                    t = self._start_time.nanoseconds
+                    data = serialize_message(msg)
+                elif self._transient_local_policy == 'keep':
+                    pass
+            else:
+                return FilterResult.DROP_MESSAGE
         if t > self._end_time.nanoseconds:
             return FilterResult.STOP_CURRENT_BAG
-        return msg
+        return (topic, data, t)

--- a/ros2bag_tools/ros2bag_tools/filter/cut.py
+++ b/ros2bag_tools/ros2bag_tools/filter/cut.py
@@ -150,7 +150,9 @@ class CutFilter(FilterExtension):
         return min(1, max(0, (end - start) / metadata.duration))
 
     def filter_topic(self, topic_metadata):
-        self._deserializer.add_topic(topic_metadata)
+        if (self._topic_qos_durability_dict[topic_metadata.name] == QoSDurabilityPolicy.TRANSIENT_LOCAL
+                and self._transient_local_policy == 'snap'):
+            self._deserializer.add_topic(topic_metadata)
         return topic_metadata
 
     def filter_msg(self, serialized_msg):


### PR DESCRIPTION
Messages with transient_local durability are currently dropped like any other message when they had a timestamp outside the cutting period. This can lead to missing static TF-trees (/tf_static) or robot descriptions (/robot_description) in cutted bags. 

This PR introduces 'transient_local_policy' as a new argument for cutting rosbags. It has three options:
- 'snap': Sets the timestamp of prior transient_local messages to the start time of the new bag.
- 'keep': Keeps prior transient_local messages with their original timestamp. This might lead to timegaps in the bag. 
- 'drop': Drops all prior transient_local messages (current behavior)

Messages after the cutting period are dropped because they should not contain any important data for the new bag anyway.

The default setting is currently 'snap' because this is in my opinion the most intuitive behavior. This is at least well suited for the transient_local durability topics like /tf_static or /robot_description that I currently deal with, as they don't change over time anyway.

Fixes #20.