### PR TITLE
Select bag timestamp and warn if msg has no header

### DIFF
--- a/ros2bag_tools/ros2bag_tools/logging.py
+++ b/ros2bag_tools/ros2bag_tools/logging.py
@@ -14,6 +14,7 @@
 
 from rclpy.logging import get_logger as rclpy_get_logger
 from rclpy.impl.rcutils_logger import RcutilsLogger
+from functools import lru_cache
 import logging
 
 from typing import Union
@@ -37,6 +38,11 @@ def getLogger(logger: Union[str, logging.Logger, RcutilsLogger, None] = None) ->
     elif logger:
         result = root.getChild(logger)
     return result
+
+
+@lru_cache(None)
+def warn_once(logger: logging.Logger, msg: str):
+    logger.warning(msg)
 
 
 class RclpyAdapter:

--- a/ros2bag_tools/test/test_filter.py
+++ b/ros2bag_tools/test/test_filter.py
@@ -29,7 +29,7 @@ from ros2bag_tools.filter.sync import SyncFilter
 from ros2bag_tools.reader import FilteredReader
 from example_interfaces.msg import String
 from diagnostic_msgs.msg import DiagnosticArray
-
+from std_msgs.msg import String as RosString
 from ros2bag_tools.verb.export import ExportVerb
 
 from .logutils import capture_at_level
@@ -251,6 +251,19 @@ def test_restamp_filter(tmp_diagnostics_bag: Path):
     msg_filtered = deserialize_message(data, DiagnosticArray)
     assert(t == 1)
     assert(msg_filtered.header.stamp.nanosec == 1)
+
+    # No header tests
+    topic_metadata = TopicMetadata(
+        '/string', 'std_msgs/msg/String', 'cdr')
+    assert(filter.filter_topic(topic_metadata) == topic_metadata)
+
+    msg = RosString()
+    msg.data = 'TestString'
+
+    bag_msg = ('/string', serialize_message(msg), 1)
+    (_, data, t) = filter.filter_msg(bag_msg)
+    msg_filtered = deserialize_message(data, RosString)
+    assert(t == 1)
 
 
 def test_sync_filter(tmp_synced_bag):


### PR DESCRIPTION
Added missing super().__init__() for RestampFilter.
Added method to warn only once (using lru_cache).
Added testcase.